### PR TITLE
[조형민] Feature/3/유저인증

### DIFF
--- a/http/users.http
+++ b/http/users.http
@@ -1,0 +1,19 @@
+POST  http://localhost:5050/users/check-nickname
+Content-Type: application/json
+
+{
+  "nickname":"별명임",
+}
+
+###
+POST  http://localhost:5050/users/sign-up
+Content-Type: application/json
+
+{
+  "email":"test@test.com",
+  "nickname":"테스트",
+  "password":"11111111"
+}
+
+###
+GET http://localhost:5050/users

--- a/http/users.http
+++ b/http/users.http
@@ -2,7 +2,7 @@ POST  http://localhost:5050/users/check-nickname
 Content-Type: application/json
 
 {
-  "nickname":"별명임",
+  "nickname":"11",
 }
 
 ###
@@ -12,6 +12,15 @@ Content-Type: application/json
 {
   "email":"test@test.com",
   "nickname":"테스트",
+  "password":"11111111"
+}
+
+###
+POST  http://localhost:5050/users/log-in
+Content-Type: application/json
+
+{
+  "email":"test@test.com",
   "password":"11111111"
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -3,15 +3,16 @@ require('dotenv').config();
 const express = require('express');
 const morgan = require('morgan');
 const router = require('./modules/index.controllers');
-const { errorHandler } = require('./modules/index.middlewares');
+const middlewares = require('./modules/index.middlewares');
 
 const app = express(); // 서버 생성
 const PORT = 5050;
 
 app.use(express.json());
 app.use(morgan('combined'));
+app.use(middlewares.authentication);
 app.use(router);
-app.use(errorHandler);
+app.use(middlewares.errorHandler);
 
 app.listen(PORT, () => {
   console.log('Server Started to listen at 5050...');

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ const { errorHandler } = require('./modules/index.middlewares');
 const app = express(); // 서버 생성
 const PORT = 5050;
 
+app.use(express.json());
 app.use(morgan('combined'));
 app.use(router);
 app.use(errorHandler);

--- a/src/db/prisma/migrations/20250214232424_update_nickname_constraints/migration.sql
+++ b/src/db/prisma/migrations/20250214232424_update_nickname_constraints/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[nickname]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "User_nickname_key" ON "User"("nickname");

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -17,7 +17,7 @@ model User {
   id                String   @id @default(uuid())
   email             String   @unique
   encryptedPassword String
-  nickname          String
+  nickname          String   @unique
   point             Int
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt

--- a/src/modules/index.middlewares.js
+++ b/src/modules/index.middlewares.js
@@ -9,36 +9,61 @@ function errorHandler(err, req, res, next) {
   res.status(statusCode).send(message);
 }
 
+// 토큰 유효성을 체크하는 미들웨어
 function authentication(req, res, next) {
-  if (req.url === '/users/sign-up' || req.url === '/users/log-in')
-    return next();
-  const authorization = req.headers.authorization;
-  if (!authorization) return next();
-  const accessToken = authorization.split('Bearer ')[1];
-  if (!accessToken) return res.status(400).send('Wrong token received...');
-
   try {
+    // 토큰 체크를 하지 않아야 하는 요청
+    if (
+      req.url === '/users/sign-up' ||
+      req.url === '/users/log-in' ||
+      req.url === '/users/check-nickname'
+    )
+      return next();
+    const authorization = req.headers.authorization;
+    if (!authorization) return next();
+    const accessToken = authorization.split('Bearer ')[1];
+    if (!accessToken) return res.status(400).send('Wrong token received...');
+
     const { sub } = jwt.verify(accessToken, process.env.JWT_SECRET_KEY);
     req.userId = sub;
 
     next();
   } catch (error) {
     // 인증 실패
-    // 유효시간이 초과된 경우
+    // 만료 기간이 지난 경우
     if (error.name === 'TokenExpiredError') {
       return res.status(419).json({
         code: 419,
-        message: '토큰이 만료되었습니다.',
+        message: 'Token expired',
       });
     }
     // 토큰의 비밀키가 일치하지 않는 경우
     if (error.name === 'JsonWebTokenError') {
       return res.status(401).json({
         code: 401,
-        message: '유효하지 않은 토큰입니다.',
+        message: 'Invalid token',
       });
     }
   }
 }
 
-module.exports = { errorHandler, authentication };
+// 로그인 여부만 체크하는 미들웨어
+function loggedInOnly(req, res, next) {
+  try {
+    const isLoggedIn = !!req.userId;
+
+    if (!isLoggedIn) throw new Error('400/Login required');
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+}
+
+const middlewares = {
+  errorHandler,
+  authentication,
+  loggedInOnly,
+};
+
+module.exports = middlewares;

--- a/src/modules/index.middlewares.js
+++ b/src/modules/index.middlewares.js
@@ -1,3 +1,5 @@
+const jwt = require('jsonwebtoken');
+
 function errorHandler(err, req, res, next) {
   console.error('에러 발생...', err);
 

--- a/src/modules/index.middlewares.js
+++ b/src/modules/index.middlewares.js
@@ -1,5 +1,5 @@
 function errorHandler(err, req, res, next) {
-  console.err('에러 발생...', err);
+  console.error('에러 발생...', err);
 
   let [statusCode, message] = err.message.split('/');
   statusCode = Number(statusCode);

--- a/src/modules/users/users.controller.js
+++ b/src/modules/users/users.controller.js
@@ -6,5 +6,7 @@ const usersRouter = express.Router();
 usersRouter.post('/sign-up', userService.signUp);
 usersRouter.post('log-in', userService.logIn);
 usersRouter.post('refresh-token', userService.refreshToken);
+usersRouter.post('/check-nickname', userService.checkNicknameExists);
+usersRouter.get('/', userService.getUsers);
 
 module.exports = usersRouter;

--- a/src/modules/users/users.controller.js
+++ b/src/modules/users/users.controller.js
@@ -4,9 +4,9 @@ const userService = require('./users.service');
 const usersRouter = express.Router();
 
 usersRouter.post('/sign-up', userService.signUp);
-usersRouter.post('log-in', userService.logIn);
+usersRouter.post('/log-in', userService.logIn);
 usersRouter.post('refresh-token', userService.refreshToken);
-usersRouter.post('/check-nickname', userService.checkNicknameExists);
+usersRouter.post('/check-nickname', userService.isAvailableNickname);
 usersRouter.get('/', userService.getUsers);
 
 module.exports = usersRouter;

--- a/src/modules/users/users.controller.js
+++ b/src/modules/users/users.controller.js
@@ -1,12 +1,14 @@
 const express = require('express');
 const userService = require('./users.service');
+const middlewares = require('../index.middlewares');
 
 const usersRouter = express.Router();
 
 usersRouter.post('/sign-up', userService.signUp);
 usersRouter.post('/log-in', userService.logIn);
-usersRouter.post('refresh-token', userService.refreshToken);
+usersRouter.post('/refresh-token', userService.refreshToken);
 usersRouter.post('/check-nickname', userService.isAvailableNickname);
 usersRouter.get('/', userService.getUsers);
+usersRouter.get('/me', middlewares.loggedInOnly, userService.getMe);
 
 module.exports = usersRouter;

--- a/src/modules/users/users.controller.js
+++ b/src/modules/users/users.controller.js
@@ -7,7 +7,7 @@ const usersRouter = express.Router();
 usersRouter.post('/sign-up', userService.signUp);
 usersRouter.post('/log-in', userService.logIn);
 usersRouter.post('/refresh-token', userService.refreshToken);
-usersRouter.post('/check-nickname', userService.isAvailableNickname);
+usersRouter.post('/check-nickname', userService.checkIsAvailableNickname);
 usersRouter.get('/', userService.getUsers);
 usersRouter.get('/me', middlewares.loggedInOnly, userService.getMe);
 

--- a/src/modules/users/users.service.js
+++ b/src/modules/users/users.service.js
@@ -130,7 +130,7 @@ async function getUsers(req, res, next) {
 }
 
 // 닉네임 중복 체크
-async function isAvailableNickname(req, res, next) {
+async function checkIsAvailableNickname(req, res, next) {
   try {
     const nickname = req.body.nickname;
 
@@ -157,7 +157,7 @@ const userService = {
   refreshToken,
   getMe,
   getUsers,
-  isAvailableNickname,
+  checkIsAvailableNickname,
 };
 
 module.exports = userService;

--- a/src/modules/users/users.service.js
+++ b/src/modules/users/users.service.js
@@ -4,6 +4,38 @@ const bcrypt = require('bcrypt');
 
 async function signUp(req, res, next) {
   try {
+    const { email, password, nickname } = req.body;
+
+    if (!validator.isEmail(email)) throw new Error('400/Malformed email');
+    if (!validator.isLength(password, { min: 8 }))
+      throw new Error('400/Password should be at least 8 characters');
+    if (!validator.isLength(nickname, { min: 2, max: 15 }))
+      throw new Error('400/Too short or Too long nickname');
+
+    // 회원가입 로직
+    // 1. 이미 가입된 email인지 확인
+    const existingEmail = await prisma.user.findUnique({
+      where: { email },
+    });
+    if (existingEmail) throw new Error('400/Email already in use');
+
+    // 2. 이미 사용중인 nickname인지 확인
+    // - 프론트엔드에서 중복체크를 하더라도 다시 한 번 하는게 맞겠지?
+    const existingNickname = await prisma.user.findUnique({
+      where: { nickname },
+    });
+    if (existingNickname) throw new Error('400/Nickname already in use');
+
+    // 3. 비밀번호 암호화
+    const encryptedPassword = await bcrypt.hash(password, 12);
+
+    // 4. 유저 생성(포인트 추가)
+    const user = await prisma.user.create({
+      data: { email, encryptedPassword, nickname, point: 0 },
+      omit: { encryptedPassword: true },
+    });
+
+    res.status(201).json(user);
   } catch (error) {
     next(error);
   }
@@ -23,6 +55,44 @@ async function refreshToken(req, res, next) {
   }
 }
 
-const userService = { signUp, logIn, refreshToken };
+async function getUsers(req, res, next) {
+  try {
+    const users = await prisma.user.findMany({
+      omit: { encryptedPassword: true },
+    });
+    res.status(200).send(users);
+  } catch (error) {
+    next(error);
+  }
+}
+
+async function checkNicknameExists(req, res, next) {
+  try {
+    const nickname = req.body.nickname;
+
+    if (!validator.isLength(nickname, { min: 2, max: 15 }))
+      throw new Error('400/Too short or Too long nickname');
+
+    const existingNickname = await prisma.user.findUnique({
+      where: { nickname },
+    });
+
+    if (existingNickname) {
+      res.status(200).send('Nickname already in use');
+    } else {
+      res.status(200).send('Available nickname');
+    }
+  } catch (error) {
+    next(error);
+  }
+}
+
+const userService = {
+  signUp,
+  logIn,
+  refreshToken,
+  checkNicknameExists,
+  getUsers,
+};
 
 module.exports = userService;


### PR DESCRIPTION
#3 

### [POST] /users/sign-up 회원가입
- 프론트엔드 요청에서 email, nickname, password를 받아 유효성 체크
- password 암호화, point:0 추가 후 user 생성/응답
### [POST] /users/log-in 로그인
- 프론트엔드 요청에서 email, password를 받아 유효성 체크
- 토큰 발급 후 응답(assecssToken, refreshToken)
### [POST] /users/refresh-token 토큰 재발급
- 프론트엔드 요청에서 prevRefreshToken을 받아 유효성 체크 및 sub, email, nickname 확인
- 해당 정보들을 담은 토큰 재발급 후 응답(assecssToken, refreshToken)
### [POST] /usres/check-nickname 닉네임 중복 체크
- 프론트엔드 요청에서 nickname을 받아 유효성 체크
- 중복 여부 체크 후 사용 가능하면 true, 불가능하면 false 응답
- 회원 가입 시 닉네임 입력란에 '중복체크' 버튼 구현 시 활용
### [GET] /users/me 내 정보 조회
- 로그인 여부 체크
- 내 정보(user) 응답(응답 시 비밀번호는 제외)

<br><br>

>**모든 기능 postman을 통해 테스트 완료하였습니다.**